### PR TITLE
Disable chrome sandbox for docker use

### DIFF
--- a/frappe_pdf/utils/pdf.py
+++ b/frappe_pdf/utils/pdf.py
@@ -66,6 +66,7 @@ def get_pdf(html, *a, **b):
 			"google-chrome",
 			"--headless",
 			"--disable-gpu",
+			"--no-sandbox",
 			"--no-pdf-header-footer",
 			"--run-all-compositor-stages-before-draw",
 			f"--print-to-pdf={pdf_file_path}",


### PR DESCRIPTION
Chrome headless won't work in docker containers (in case of frappe_docker for e.g.)

Disabling sandbox mode allows for this, however, it comes at some risks too. Since print formats can be trusted, I think those are negligible. 

Further details as of why chrome won't work in docker container:

> The problem seems to be that creating an isolated environment involves cloning a "user namespace." With the default setting of unprivileged_userns_clone=0 you can clone a namespace once, however, once inside the namespace it's not possible to further clone the namespace again. Since both docker and chrome create a sandboxed namespace, it's not possible to run chrome from inside a docker container without jumping through additional hoops. Note that the same issue arises when running an electron app which is packaged as an AppImage.

Source: [Stackexchance post](https://security.stackexchange.com/a/239202)