### PR TITLE
feat: Add missing support for multi-pdf and password encrypted pdf

### DIFF
--- a/frappe_pdf/utils/pdf.py
+++ b/frappe_pdf/utils/pdf.py
@@ -6,77 +6,88 @@ import frappe
 from frappe.utils import get_url
 
 URLS_NOT_HTTP_TAG_PATTERN = re.compile(
-	r'(href|src){1}([\s]*=[\s]*[\'"]?)((?!http)[^\'">]+)([\'"]?)'
+    r'(href|src){1}([\s]*=[\s]*[\'"]?)((?!http)[^\'">]+)([\'"]?)'
 )  # href=/assets/...
 URL_NOT_HTTP_NOTATION_PATTERN = re.compile(
-	r'(:[\s]?url)(\([\'"]?)((?!http)[^\'">]+)([\'"]?\))'
+    r'(:[\s]?url)(\([\'"]?)((?!http)[^\'">]+)([\'"]?\))'
 )  # background-image: url('/assets/...')
 
+
 def scrub_urls(html: str) -> str:
-	return expand_relative_urls(html)
+    return expand_relative_urls(html)
 
 
 def expand_relative_urls(html: str) -> str:
-	# expand relative urls
-	url = get_url()
-	if url.endswith("/"):
-		url = url[:-1]
-	
-	URLS_HTTP_TAG_PATTERN = re.compile(
-		r'(href|src)([\s]*=[\s]*[\'"]?)((?:{0})[^\'">]+)([\'"]?)'.format(re.escape(url.replace("https://", "http://")))
-	)  # href='https://...
-	
-	URL_HTTP_NOTATION_PATTERN = re.compile(
-		r'(:[\s]?url)(\([\'"]?)((?:{0})[^\'">]+)([\'"]?\))'.format(re.escape(url.replace("https://", "http://")))
-	)  # background-image: url('/assets/...')	
+    # expand relative urls
+    url = get_url()
+    if url.endswith("/"):
+        url = url[:-1]
 
+    URLS_HTTP_TAG_PATTERN = re.compile(
+        r'(href|src)([\s]*=[\s]*[\'"]?)((?:{0})[^\'">]+)([\'"]?)'.format(
+            re.escape(url.replace("https://", "http://"))
+        )
+    )  # href='https://...
 
-	def _expand_relative_urls(match):
-		to_expand = list(match.groups())
+    URL_HTTP_NOTATION_PATTERN = re.compile(
+        r'(:[\s]?url)(\([\'"]?)((?:{0})[^\'">]+)([\'"]?\))'.format(
+            re.escape(url.replace("https://", "http://"))
+        )
+    )  # background-image: url('/assets/...')
 
-		if not to_expand[2].startswith(("mailto", "data:", "tel:")):
-			if not to_expand[2].startswith(url):
-				if not to_expand[2].startswith("/"):
-					to_expand[2] = "/" + to_expand[2]
-				to_expand.insert(2, url)
-		
-		# add session id
-		if frappe.session and frappe.session.sid and hasattr(frappe.local, "request") and len(to_expand) > 2:
-			if "?" in to_expand[-2]:
-				to_expand[-2] += f"&sid={frappe.session.sid}"
-			else:
-				to_expand[-2] += f"?sid={frappe.session.sid}"
+    def _expand_relative_urls(match):
+        to_expand = list(match.groups())
 
-		return "".join(to_expand)
+        if not to_expand[2].startswith(("mailto", "data:", "tel:")):
+            if not to_expand[2].startswith(url):
+                if not to_expand[2].startswith("/"):
+                    to_expand[2] = "/" + to_expand[2]
+                to_expand.insert(2, url)
 
-	html = URLS_HTTP_TAG_PATTERN.sub(_expand_relative_urls, html)
-	html = URLS_NOT_HTTP_TAG_PATTERN.sub(_expand_relative_urls, html)
-	html = URL_NOT_HTTP_NOTATION_PATTERN.sub(_expand_relative_urls, html)
-	html = URL_HTTP_NOTATION_PATTERN.sub(_expand_relative_urls, html)
+        # add session id
+        if (
+            frappe.session
+            and frappe.session.sid
+            and hasattr(frappe.local, "request")
+            and len(to_expand) > 2
+        ):
+            if "?" in to_expand[-2]:
+                to_expand[-2] += f"&sid={frappe.session.sid}"
+            else:
+                to_expand[-2] += f"?sid={frappe.session.sid}"
 
-	return html
+        return "".join(to_expand)
+
+    html = URLS_HTTP_TAG_PATTERN.sub(_expand_relative_urls, html)
+    html = URLS_NOT_HTTP_TAG_PATTERN.sub(_expand_relative_urls, html)
+    html = URL_NOT_HTTP_NOTATION_PATTERN.sub(_expand_relative_urls, html)
+    html = URL_HTTP_NOTATION_PATTERN.sub(_expand_relative_urls, html)
+
+    return html
+
 
 def get_pdf(html, *a, **b):
-	pdf_file_path = f'/tmp/{frappe.generate_hash()}.pdf'
-	html = scrub_urls(html)
-	with tempfile.NamedTemporaryFile(mode="w+", suffix=f"{frappe.generate_hash()}.html", delete=True) as html_file:
-		html_file.write(html)
-		html_file.seek(0)
-		chrome_command = [
-			"google-chrome",
-			"--headless",
-			"--disable-gpu",
-			"--no-sandbox",
-			"--no-pdf-header-footer",
-			"--run-all-compositor-stages-before-draw",
-			f"--print-to-pdf={pdf_file_path}",
-			html_file.name
+    pdf_file_path = f"/tmp/{frappe.generate_hash()}.pdf"
+    html = scrub_urls(html)
+    with tempfile.NamedTemporaryFile(
+        mode="w+", suffix=f"{frappe.generate_hash()}.html", delete=True
+    ) as html_file:
+        html_file.write(html)
+        html_file.seek(0)
+        chrome_command = [
+            "google-chrome",
+            "--headless",
+            "--disable-gpu",
+            "--no-sandbox",
+            "--no-pdf-header-footer",
+            "--run-all-compositor-stages-before-draw",
+            f"--print-to-pdf={pdf_file_path}",
+            html_file.name,
+        ]
+        subprocess.run(chrome_command, shell=False)
+        content = None
+        with open(pdf_file_path, "rb") as f:
+            content = f.read()
+        os.remove(pdf_file_path)
 
-		]
-		subprocess.run(chrome_command, shell=False)
-		content = None
-		with open(pdf_file_path, 'rb') as f:
-			content = f.read()
-		os.remove(pdf_file_path)
-	
-	return content
+    return content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
+    "pypdf"
 ]
 
 [build-system]


### PR DESCRIPTION
ATM frappe-pdf won't print anything if you select e.g. multiple quotations and use the quick-action "print". This PR will add support to print & append multiple pdf.

Additionally, frappe's default password-encryption for pdf files will be enabled too.


Note: Ruff formatted the whole python file acoording their standards - therefore the first commit.