### PR TITLE
Frappe 13 not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Google Chrome's headless mode is preferred due to its robust support for modern 
 5. Google Chrome should be installed on the server. (currently working on replacing the manual installation of google-chrome) 
 
 ## Supported Frappe Versions
-- version-13
+- version-13 is not supported as it uses python 2x
 - version-14
 - version-15
 


### PR DESCRIPTION
Hi,
First of all, I’d like to thank you for the great work on the frappe-pdf app — it’s a really useful tool, and I appreciate the effort you've put into building and sharing it with the community. I wanted to bring an issue to your attention regarding installation compatibility. I’ve successfully installed and tested the app on ERPNext versions 14 and 15 without any problems. However, when I attempted to install it on a server running ERPNext v13, I encountered an error related to the Python version requirement. Initially, when I used bench get-app, the process failed because it couldn’t find a setup.py file. I manually added a minimal setup.py to get around that, but then encountered another issue during the bench setup requirements step. Here are the details:
ERPNext Version: 13.41.1
Frappe Version: 13.43.2
System Default Python: 2.7.17
Error: ERROR: Package 'frappe-pdf' requires a different Python: 3.6.9 not in '>=3.10' I noticed that the pyproject.toml in the app specifies requires-python = ">=3.10", which isn't compatible with the older Python versions supported by ERPNext 13. This causes the installation to fail during bench setup requirements. Would you consider adding backward compatibility for older Python versions (>=3.6), or possibly releasing a separate branch for v13 support if feasible? Thanks again for the great work — looking forward to hearing your thoughts on this. Best regards,
Usman